### PR TITLE
Correct crashing call to perform_get_address_size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 6502 Architecture Plugin (v2.0.1)
+# 6502 Architecture Plugin (v2.0.2)
 Author: **Vector 35 Inc**
 
 _An architecture plugin for 6502 and binary view for NES roms._

--- a/__init__.py
+++ b/__init__.py
@@ -708,7 +708,7 @@ class NESView(BinaryView):
 		return True
 
 	def perform_get_address_size(self) -> int:
-		return self.address_size
+		return self.arch.address_size
 
 	def perform_get_entry_point(self) -> int:
 		return struct.unpack("<H", self.read(0xfffc, 2))[0]

--- a/plugin.json
+++ b/plugin.json
@@ -25,7 +25,7 @@
         "Windows": "no special instructions, package manager is recommended"
     },
     "dependencies": {},
-    "version": "2.0.1",
+    "version": "2.0.2",
     "author": "Vector 35 Inc",
     "minimumbinaryninjaversion": 1200
 }


### PR DESCRIPTION
Fixed 6502 plugin crash on Windows caused by an incorrect return in perform_get_address_size